### PR TITLE
Configure LXD socket for LXD exporter

### DIFF
--- a/attributes/lxd_exporter.rb
+++ b/attributes/lxd_exporter.rb
@@ -12,4 +12,6 @@ default["lxd_exporter"]["version"] = "0.1.1"
 default["lxd_exporter"]["checksum"] = "45f5502bc88c8f7c329103faa52bcf3b8c76d44f0a6dd045a791b8aceebddace"
 default["lxd_exporter"]["binary_url"] = "https://github.com/BaritoLog/lxd_exporter/releases/download/v#{node["lxd_exporter"]["version"]}/lxd_exporter.linux-amd64.tar.gz"
 
+default["lxd_exporter"]["lxd_socket"] = "/var/snap/lxd/common/lxd/unix.socket"
+
 default["lxd_exporter"]["flags"]["port"] = "9142"

--- a/recipes/lxd_exporter.rb
+++ b/recipes/lxd_exporter.rb
@@ -25,6 +25,7 @@ systemd_unit "lxd_exporter.service" do
             After=network.target
 
             [Service]
+            Environment=LXD_SOCKET=#{node["lxd_exporter"]["lxd_socket"]}
             ExecStart=/bin/bash -ce 'exec #{node["lxd_exporter"]["binary"]} #{Gitlab::Prometheus.kingpin_flags_for(node, "lxd_exporter")} >> "#{node["lxd_exporter"]["log_dir"]}/lxd_exporter.log" 2>&1'
             User=#{node["prometheus"]["user"]}
             Restart=always

--- a/test/integration/lxd_exporter/default_test.rb
+++ b/test/integration/lxd_exporter/default_test.rb
@@ -11,6 +11,10 @@ control "lxd_exporter install" do
     it { should be_running }
   end
 
+  describe file("/etc/systemd/system/lxd_exporter.service") do
+    its("content") { should include "Environment=LXD_SOCKET=/var/snap/lxd/common/lxd/unix.socket" }
+  end
+
   describe port(9142) do
     it { should be_listening }
   end


### PR DESCRIPTION
LXD socket needs to be configured so it refers to the correct socket.

Corresponding issue: #14.