### PR TITLE
Append prometheus user to lxd group

### DIFF
--- a/recipes/lxd_exporter.rb
+++ b/recipes/lxd_exporter.rb
@@ -6,6 +6,11 @@
 
 include_recipe "prometheus::user"
 
+group "lxd" do
+  append true
+  members "prometheus"
+end
+
 ark ::File.basename(node["lxd_exporter"]["dir"]) do
   url node["lxd_exporter"]["binary_url"]
   checksum node["lxd_exporter"]["checksum"]

--- a/test/integration/lxd_exporter/default_test.rb
+++ b/test/integration/lxd_exporter/default_test.rb
@@ -2,6 +2,10 @@ control "lxd_exporter install" do
   impact 1.0
   title "Tests Prometheus LXD Exporter Installation"
 
+  describe user("prometheus") do
+    its("groups") { should include "lxd" }
+  end
+
   describe file("/opt/prometheus/lxd_exporter/lxd_exporter") do
     its("mode") { should cmp "0755" }
   end


### PR DESCRIPTION
Add access for `prometheus` user so it can access `lxd` socket and export its metrics.

Corresponding issue: #15.