### PR TITLE
Update postgres_exporter to v0.7.0

### DIFF
--- a/attributes/postgres_exporter.rb
+++ b/attributes/postgres_exporter.rb
@@ -10,8 +10,8 @@ default["postgres_exporter"]["log_dir"] = "#{node["prometheus"]["log_dir"]}"
 default["postgres_exporter"]["binary"] = "#{node["postgres_exporter"]["dir"]}/postgres_exporter"
 
 # Postgres Exporter version
-default["postgres_exporter"]["version"] = "0.5.1"
-default["postgres_exporter"]["checksum"] = "7b00cc56d83e3a8f5a58d2b0f17f12b1b3b1b1ecccffffc3e8446ff187058c0e"
+default["postgres_exporter"]["version"] = "0.7.0"
+default["postgres_exporter"]["checksum"] = "a8409e64c5f377134e15cfd40a2da973c059f0955346379606a505677354125a"
 default["postgres_exporter"]["binary_url"] = "https://github.com/wrouesnel/postgres_exporter/releases/download/v#{node["postgres_exporter"]["version"]}/postgres_exporter_v#{node["postgres_exporter"]["version"]}_linux-amd64.tar.gz"
 
 # Postgres Exporter config


### PR DESCRIPTION
`postgres_exporter` 0.7.0 allows `postgres_exporter` to connect to PostgreSQL server which password contains `=` sign.

Corresponding issue: #21.