### PR TITLE
Update lxd_exporter to 0.2.0

### DIFF
--- a/attributes/lxd_exporter.rb
+++ b/attributes/lxd_exporter.rb
@@ -8,9 +8,9 @@ default["lxd_exporter"]["dir"] = "#{node["prometheus"]["dir"]}/lxd_exporter"
 default["lxd_exporter"]["log_dir"] = "#{node["prometheus"]["log_dir"]}"
 default["lxd_exporter"]["binary"] = "#{node["lxd_exporter"]["dir"]}/lxd_exporter"
 
-default["lxd_exporter"]["version"] = "0.1.1"
-default["lxd_exporter"]["checksum"] = "45f5502bc88c8f7c329103faa52bcf3b8c76d44f0a6dd045a791b8aceebddace"
-default["lxd_exporter"]["binary_url"] = "https://github.com/BaritoLog/lxd_exporter/releases/download/v#{node["lxd_exporter"]["version"]}/lxd_exporter.linux-amd64.tar.gz"
+default["lxd_exporter"]["version"] = "0.2.0"
+default["lxd_exporter"]["checksum"] = "310677ca3a0aae566d4e83ec59c5858024e832b972e65fed6811fe5e7abf0e43"
+default["lxd_exporter"]["binary_url"] = "https://github.com/BaritoLog/lxd_exporter/releases/download/v#{node["lxd_exporter"]["version"]}/lxd_exporter-#{node["lxd_exporter"]["version"]}.linux-amd64.tar.xz"
 
 default["lxd_exporter"]["lxd_socket"] = "/var/snap/lxd/common/lxd/unix.socket"
 


### PR DESCRIPTION
This version exports stopped containers as `0` instead of missing metrics.

Corresponding issue: #23.